### PR TITLE
Update active elements from the November 28, 2024 exec

### DIFF
--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -3197,7 +3197,7 @@
           <td>Sky Core Governance Security - Governance Security Delay Requirements - Pause Delay Current Value
           </td>
           <td>Core</td>
-          <td>The GSM Pause Delay is: 16 hours</td>
+          <td>The GSM Pause Delay is: 30 hours</td>
         </tr>
         <tr>
           <td>
@@ -6757,7 +6757,7 @@
           </td>
           <td>Core Stability Parameters - Parameters - Dai Savings Rate Current Value</td>
           <td>Core</td>
-          <td>The current value of the Dai Savings Rate is 7.5%.</td>
+          <td>The current value of the Dai Savings Rate is 8.5%.</td>
         </tr>
         <tr>
           <td>
@@ -7802,7 +7802,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - ETH-A</td>
           <td>Core</td>
-          <td>Current ETH-A parameters are:• Stability Fee: 8.25%• Liquidation Ratio: 145%• DC-IAM line:
+          <td>Current ETH-A parameters are:• Stability Fee: 9.25%• Liquidation Ratio: 145%• DC-IAM line:
             15,000,000,000 Dai• DC-IAM gap: 150,000,000 Dai• DC-IAM ttl: 21,600 seconds• cut: 99.00%• step: 90
             seconds• buf: 110.00%• cusp: 45.00%• tail: 7,200 seconds• chip: 0.10%• tip: 250• chop: 13%• hole:
             40,000,000 Dai• dust: 7,500 Dai</td>
@@ -7814,7 +7814,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - ETH-B</td>
           <td>Core</td>
-          <td>Current ETH-B parameters are:• Stability Fee: 8.75%• Liquidation Ratio: 130%• DC-IAM line:
+          <td>Current ETH-B parameters are:• Stability Fee: 9.75%• Liquidation Ratio: 130%• DC-IAM line:
             250,000,000 Dai• DC-IAM gap: 20,000,000 Dai• DC-IAM ttl: 21,600 seconds• cut: 99.00%• step: 60
             seconds• buf: 110.00%• cusp: 45.00%• tail: 4,800 seconds• chip: 0.10%• tip: 250• chop: 13%• hole:
             15,000,000 Dai• dust: 25,000 Dai</td>
@@ -7826,7 +7826,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - ETH-C</td>
           <td>Core</td>
-          <td>Current ETH-C parameters are:• Stability Fee: 8.00%• Liquidation Ratio: 170%• DC-IAM line:
+          <td>Current ETH-C parameters are:• Stability Fee: 9.00%• Liquidation Ratio: 170%• DC-IAM line:
             2,000,000,000 Dai• DC-IAM gap: 100,000,000 Dai• DC-IAM ttl: 28,800 seconds• cut: 99.00%• step: 90
             seconds• buf: 110.00%• cusp: 45.00%• tail: 7,200 seconds• chip: 0.10%• tip: 250• chop: 13%• hole:
             35,000,000 Dai• dust: 3,500 Dai</td>
@@ -7838,7 +7838,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - WSTETH-A</td>
           <td>Core</td>
-          <td>Current WSTETH-A parameters are:• Stability Fee: 9.25%• Liquidation Ratio: 150%• DC-IAM line:
+          <td>Current WSTETH-A parameters are:• Stability Fee: 10.25%• Liquidation Ratio: 150%• DC-IAM line:
             750,000,000 Dai• DC-IAM gap: 30,000,000 Dai• DC-IAM ttl: 43,200 seconds• cut: 99.00%• step: 90
             seconds• buf: 110.00%• cusp: 45.00%• tail: 7,200 seconds• chip: 0.10%• tip: 250• chop: 13%• hole:
             30,000,000 Dai• dust: 7,500 Dai</td>
@@ -7850,7 +7850,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - WSTETH-B</td>
           <td>Core</td>
-          <td>Current WSTETH-B parameters are:• Stability Fee: 9.00%• Liquidation Ratio: 175%• DC-IAM line:
+          <td>Current WSTETH-B parameters are:• Stability Fee: 10.00%• Liquidation Ratio: 175%• DC-IAM line:
             1,000,000,000 Dai• DC-IAM gap: 45,000,000 Dai• DC-IAM ttl: 43,200 seconds• cut: 99.00%• step: 90
             seconds• buf: 110.00%• cusp: 45.00%• tail: 7,200 seconds• chip: 0.10%• tip: 250• chop: 13%• hole:
             20,000,000 Dai• dust: 3,500 Dai</td>
@@ -7862,7 +7862,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - WBTC-A</td>
           <td>Core</td>
-          <td>Current WBTC-A parameters are:• Stability Fee: 11.25%• Liquidation Ratio: 150%• DC-IAM line: 0 Dai•
+          <td>Current WBTC-A parameters are:• Stability Fee: 12.25%• Liquidation Ratio: 150%• DC-IAM line: 0 Dai•
             DC-IAM gap: 4,000,000 Dai• DC-IAM ttl: 86,400 seconds• cut: 99.00%• step: 90 seconds• buf: 110.00%•
             cusp: 45.00%• tail: 7,200 seconds• chip: 0.10%• tip: 250• chop: 0%• hole: 10,000,000 Dai• dust:
             7,500 Dai</td>
@@ -7874,7 +7874,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - WBTC-B</td>
           <td>Core</td>
-          <td>Current WBTC-B parameters are:• Stability Fee: 11.75%• Liquidation Ratio: 150%• DC-IAM line: 0 Dai•
+          <td>Current WBTC-B parameters are:• Stability Fee: 12.75%• Liquidation Ratio: 150%• DC-IAM line: 0 Dai•
             DC-IAM gap: 2,000,000 Dai• DC-IAM ttl: 86,400 seconds• cut: 99.00%• step: 60 seconds• buf: 110.00%•
             cusp: 45.00%• tail: 4,800 sec• chip: 0.10%• tip: 250• chop: 0%• hole: 5,000,000 Dai• dust: 25,000
             Dai</td>
@@ -7886,7 +7886,7 @@
           </td>
           <td>Measures For Endgame Transition - Native Vault Engine - WBTC-C</td>
           <td>Core</td>
-          <td>Current WBTC-C parameters are:• Stability Fee: 11.00%• Liquidation Ratio: 175%• DC-IAM line: 0 Dai•
+          <td>Current WBTC-C parameters are:• Stability Fee: 12.00%• Liquidation Ratio: 175%• DC-IAM line: 0 Dai•
             DC-IAM gap: 8,000,000 Dai• DC-IAM ttl: 86,400 seconds• cut: 99.00%• step: 90 seconds• buf: 110.00%•
             cusp: 45.00%• tail: 7,200 seconds• chip: 0.10%• tip: 250• chop: 0%• hole: 10,000,000 Dai• dust:
             3,500 Dai</td>
@@ -8799,7 +8799,7 @@
             Collateral: Yes• Borrowing: Yes• Isolated Collateral: No• Isolated Borrowing: Yes• Siloed Borrowing:
             No• Flash Loan Enabled: Yes
             The Dai Borrow Rate is set directly by the Stability Facilitators in consultation with the Stability Scope Advisors, and is 
-            currently equal to 8.50%, which is the Dai Savings Rate plus 1%.</td>
+            currently equal to ~9.5%, which is the Dai Savings Rate plus 1%.</td>
         </tr>
         <tr>
           <td>
@@ -8834,7 +8834,7 @@
           </td>
           <td>Measures For Endgame Transition - SparkLend Risk Parameters - WBTC Risk Parameters</td>
           <td>Core</td>
-          <td>The current WBTC risk parameters are:• LTV: 0%• Liquidation Threshold: 65%• E-mode Category: N/A•
+          <td>The current WBTC risk parameters are:• LTV: 0%• Liquidation Threshold: 60%• E-mode Category: N/A•
             Liquidation Bonus: 7%• Reserve Factor: 20%• Supply Cap: Set by cap automater• Borrow Cap: Set by cap
             automater• Optimal Utilization: 60%• Isolated Debt Ceiling: N/A• Base Rate: 0%• Slope 1: 2%• Slope
             2: 300%• Reserve State: Active• Collateral: Yes• Borrowing: No• Isolated Collateral: No• Isolated


### PR DESCRIPTION
Active element update following the [November 28, 2024 executive vote](https://vote.makerdao.com/executive/template-executive-vote-aave-lido-market-usds-ddm-parameters-adjustments-allocator-spark-a-dc-iam-changes-surplus-buffer-upper-limit-increase-stability-fee-changes-savings-rate-changes-gsm-delay-increase-addition-of-ilks-to-the-linemom-addition-of-standby-spells-to-the-chainlog-funding-disbursements-esm-minimum-threshold-increase-ad-and-atlas-core-development-compensation-spark-proxy-spell-november-28-2024):

- [Surplus Buffer Upper Limit Increase](https://vote.makerdao.com/polling/QmZfYrR7)
- [Stability Fee Changes](https://forum.sky.money/t/stability-scope-parameter-changes-18-sfs-dsr-ssr-spark-effective-dai-borrow-rate-spark-liquidity-layer/25593)
- [Savings Rate Changes](https://forum.sky.money/t/stability-scope-parameter-changes-18-sfs-dsr-ssr-spark-effective-dai-borrow-rate-spark-liquidity-layer/25593)
- [GSM Pause Delay Increase](https://forum.sky.money/t/november-28th-spell-parameter-proposal-esm-threshold-gsm-delay-increase/25579)
- [[Mainnet] Spark Effective DAI Borrow Rate Increase](https://forum.sky.money/t/stability-scope-parameter-changes-18-sfs-dsr-ssr-spark-effective-dai-borrow-rate-spark-liquidity-layer/25593)
- [[Mainnet] Adjust SparkLend Parameters for WBTC](https://vote.makerdao.com/polling/QmSxJJ6Z)
- [[Mainnet] Adjust SparkLend Parameters for cbBTC](https://vote.makerdao.com/polling/QmaxFZfF)

@VoteWizard, @CivicSage3 