### PR TITLE
cbBTC risk parameter update

### DIFF
--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -8930,7 +8930,7 @@
           </td>
           <td>Measures For Endgame Transition - SparkLend Risk Parameters - cbBTC Risk Parameters</td>
           <td>Core</td>
-          <td>The current cbBTC risk parameters are:• LTV: 65%• Liquidation Threshold: 70%• E-mode Category: N/A
+          <td>The current cbBTC risk parameters are:• LTV: 74%• Liquidation Threshold: 75%• E-mode Category: N/A
             • Liquidation Bonus: 8%• Reserve Factor: 20%• Supply Cap: 500 cbBTC• Borrow Cap: 50 cbBTC
             • Optimal Utilization: 60%• Isolated Debt Ceiling: N/A• Base Rate: 0%• Slope 1: 4%
             • Slope 2: 300%• Reserve State: Active• Collateral: Yes• Borrowing: Yes• Isolated Collateral: No•


### PR DESCRIPTION
Ratifying exec: https://vote.makerdao.com/executive/template-executive-vote-aave-lido-market-usds-ddm-parameters-adjustments-allocator-spark-a-dc-iam-changes-surplus-buffer-upper-limit-increase-stability-fee-changes-savings-rate-changes-gsm-delay-increase-addition-of-ilks-to-the-linemom-addition-of-standby-spells-to-the-chainlog-funding-disbursements-esm-minimum-threshold-increase-ad-and-atlas-core-development-compensation-spark-proxy-spell-november-28-2024

@boet1 , @VoteWizard 